### PR TITLE
fix vuepress marker matcher

### DIFF
--- a/src/hypers/vuepress.ts
+++ b/src/hypers/vuepress.ts
@@ -8,7 +8,7 @@ import { Data } from './types'
 // - `(.+)`
 // - `\n`
 // - `(:::)` + `(?=\n|$)`
-const matcher = /(?<=^|\n)(:::.*)\n(.+)\n(:::)(?=\n|$)/g
+const matcher = /(?<=^|\n)(:::.*)\n([\s\S]+?)\n(:::)(?=\n|$)/g
 
 const parser = (data: Data): Data => {
   data.modifiedContent = data.modifiedContent.replace(

--- a/test/uncategorized.test.ts
+++ b/test/uncategorized.test.ts
@@ -1,11 +1,38 @@
 import { describe, test, expect } from 'vitest'
 
-import run from '../src/run'
+import run, { Options } from '../src/run'
 
-const lint = (...args: [any]) => run(...args).result
+const lint = (...args) => run(...(args as [string, Options])).result
 
 describe('uncategorized cases', () => {
+  // https://github.com/Jinjiang/zhlint/issues/11
   test('#11: hyphen between number', () => {
     expect(lint('1-1')).toBe('1 - 1')
+  })
+  // https://github.com/Jinjiang/zhlint/issues/23
+  test('#23: two dots only', () => {
+    expect(lint('..')).toBe(
+      '..'
+    )
+  })
+  test('VitePress tags', () => {
+    const text = `![Chrome 开发者工具正在通过标签展示无障碍访问的 input 框的名字](./images/AccessibleLabelChromeDevTools.png)
+
+:::warning 警告：
+你可能还见过这样的包裹 input 框的标签：
+
+\`\`\`vue-html
+<label>
+  名字：
+  <input type="text" name="name" id="name" v-model="name" />
+</label>
+\`\`\`
+
+但我们仍建议你显式地为 input 元素设置 id 相匹配的标签，以更好地实现无障碍访问。
+:::
+
+#### \`aria-label\` {#aria-label}
+`
+    expect(lint(text)).toBe(text)
   })
 })


### PR DESCRIPTION
To be particular, multiline vuepress [custom containers](https://vuepress.vuejs.org/guide/markdown.html#custom-containers) with non-greedy mode.