### PR TITLE
feat: rule logger in dev mode

### DIFF
--- a/src/rules/case-abbr.ts
+++ b/src/rules/case-abbr.ts
@@ -53,7 +53,7 @@ const hasAbbr = (
   }
 }
 
-const handler: Handler = (token: Token, index, group: GroupToken) => {
+const caseAbbrHandler: Handler = (token: Token, index, group: GroupToken) => {
   if (token.content === '.') {
     // end of the content or has space after or full-width content after
     const tokenAfter = findTokenAfter(group, token)
@@ -82,4 +82,4 @@ const handler: Handler = (token: Token, index, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseAbbrHandler

--- a/src/rules/case-backslash.ts
+++ b/src/rules/case-backslash.ts
@@ -30,7 +30,7 @@ const validate = (token: Token, type: string, condition: boolean): void => {
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseBackSlashHandler: Handler = (token: Token, _, group: GroupToken) => {
   // half width and no raw space after -> no space after
   // full width before -> one space before
   if (token.type.match(/^punctuation-/) && token.content === '\\') {
@@ -75,4 +75,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseBackSlashHandler

--- a/src/rules/case-datetime-zh.ts
+++ b/src/rules/case-datetime-zh.ts
@@ -29,7 +29,7 @@ const validate = (token: Token, type: string, condition: boolean): void => {
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseDateTimeZhHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === 'content-half') {
     if (!token.modifiedContent?.match(/^[\d.]+$/)) {
       return
@@ -62,4 +62,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseDateTimeZhHandler

--- a/src/rules/case-datetime.ts
+++ b/src/rules/case-datetime.ts
@@ -11,7 +11,7 @@ import {
   removeValidation
 } from './util'
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseDateTimeHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type.match(/^punctuation-/) && token.content === ':') {
     const tokenBefore = findTokenBefore(group, token)
     const nonMarkTokenBefore = findNonMarkTokenBefore(group, token)
@@ -36,4 +36,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseDateTimeHandler

--- a/src/rules/case-ellipsis.ts
+++ b/src/rules/case-ellipsis.ts
@@ -28,7 +28,7 @@ const validate = (token: Token, type: string, condition: boolean): void => {
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseEllipsisHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.content === '.') {
     const tokenBefore = findTokenBefore(group, token)
 
@@ -84,4 +84,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseEllipsisHandler

--- a/src/rules/case-html-entity.ts
+++ b/src/rules/case-html-entity.ts
@@ -7,7 +7,7 @@ import {
 } from '../parser'
 import { findTokenBefore, removeValidation } from './util'
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseHtmlEntityHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.content === ';') {
     const tokenBefore = findTokenBefore(group, token)
     if (
@@ -29,4 +29,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseHtmlEntityHandler

--- a/src/rules/case-html-space.ts
+++ b/src/rules/case-html-space.ts
@@ -5,7 +5,7 @@ import {
 } from '../parser'
 import { findTokenBefore } from './util'
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseHtmlSpaceHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === 'content-hyper') {
     if (
       token.content.match(/^<(b|i|u|s|strong|em|strike|del|sub|sup)(\s.*)?>$/)
@@ -24,4 +24,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseHtmlSpaceHandler

--- a/src/rules/case-linebreak.ts
+++ b/src/rules/case-linebreak.ts
@@ -2,11 +2,11 @@ import { ValidationTarget } from '../report'
 import { Handler, MutableToken as Token } from '../parser'
 import { removeValidation } from './util'
 
-const handler: Handler = (token: Token) => {
+const caseLinebreakHandler: Handler = (token: Token) => {
   if (token.spaceAfter && token.spaceAfter.match(/\n/)) {
     removeValidation(token, '', ValidationTarget.SPACE_AFTER)
     token.modifiedSpaceAfter = token.spaceAfter
   }
 }
 
-export default handler
+export default caseLinebreakHandler

--- a/src/rules/case-math-exp.ts
+++ b/src/rules/case-math-exp.ts
@@ -38,7 +38,7 @@ const validate = (
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseMathExpHandler: Handler = (token: Token, _, group: GroupToken) => {
   // calculation: space in both sides
   // - 1 + 1 = 2
   // x 2020/01/01
@@ -173,4 +173,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseMathExpHandler

--- a/src/rules/case-raw.ts
+++ b/src/rules/case-raw.ts
@@ -7,7 +7,7 @@ import {
 } from '../parser'
 import { findTokenBefore, findTokenAfter, removeValidation } from './util'
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const caseRawHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (
     token.type.match(/^punctuation-/) &&
     '/|'.indexOf(token.modifiedContent || token.content) >= 0
@@ -28,4 +28,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default caseRawHandler

--- a/src/rules/case-traditional.ts
+++ b/src/rules/case-traditional.ts
@@ -26,7 +26,7 @@ const validate = (
 ): void =>
   addValidation(token, 'case-traditional', type, messages.default(args))
 
-const handler: Handler = (token: Token) => {
+const caseTraditionalHandler: Handler = (token: Token) => {
   if (token.type === GroupTokenType.GROUP) {
     if (token.modifiedStartContent && replaceMap[token.modifiedStartContent]) {
       validate(token, ValidationTarget.START_CONTENT, {
@@ -45,4 +45,4 @@ const handler: Handler = (token: Token) => {
   }
 }
 
-export default handler
+export default caseTraditionalHandler

--- a/src/rules/mark-hyper.ts
+++ b/src/rules/mark-hyper.ts
@@ -45,7 +45,7 @@ const checkSpace = (group: GroupToken, markSeq: Token[]): boolean => {
   return false
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const markHyperHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === SingleTokenType.MARK_HYPER) {
     const markSeq = findMarkSeq(group, token)
     const tokenBeforeMarkSeq = findTokenBefore(group, markSeq[0])
@@ -77,4 +77,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default markHyperHandler

--- a/src/rules/mark-raw.ts
+++ b/src/rules/mark-raw.ts
@@ -58,10 +58,10 @@ const addSpaceOutside = (group: GroupToken, token: Token): void => {
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const markRawHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (isInlineCode(token)) {
     addSpaceOutside(group, token)
   }
 }
 
-export default handler
+export default markRawHandler

--- a/src/rules/space-brackets.ts
+++ b/src/rules/space-brackets.ts
@@ -83,7 +83,7 @@ const checkSide = (
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const spaceBracketsHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === SingleTokenType.MARK_BRACKETS) {
     const isRawContent = token.modifiedContent === token.content
     const size = token.modifiedContent.match(/[()]/)
@@ -130,4 +130,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default spaceBracketsHandler

--- a/src/rules/space-full-width-content.ts
+++ b/src/rules/space-full-width-content.ts
@@ -47,7 +47,7 @@ const validate = (token: Token, type: string, condition: boolean): void => {
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const spaceFullWidthContentHandler: Handler = (token: Token, _, group: GroupToken) => {
   // - if next content width different
   //   - if there is a mark
   //     - add a space outside mark
@@ -161,4 +161,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default spaceFullWidthContentHandler

--- a/src/rules/space-punctuation.ts
+++ b/src/rules/space-punctuation.ts
@@ -39,7 +39,7 @@ const validate = (token: Token, type: string, condition: boolean): void => {
  * full-width -> no space
  * half-width -> one space after
  */
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const spacePunctuationHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type.match(/^punctuation-/)) {
     // Skip special punctuation which doesn't fit this rule.
     if ('/[&%-'.indexOf(token.modifiedContent) >= 0) {
@@ -131,4 +131,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default spacePunctuationHandler

--- a/src/rules/space-quotes.ts
+++ b/src/rules/space-quotes.ts
@@ -59,7 +59,7 @@ const checkOutside = (
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const spaceQuotesHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === GroupTokenType.GROUP) {
     // no space inside
     validate(
@@ -118,4 +118,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default spaceQuotesHandler

--- a/src/rules/unify-punctuation.ts
+++ b/src/rules/unify-punctuation.ts
@@ -70,7 +70,7 @@ const validate = (
   }
 }
 
-const handler: Handler = (token: Token, _, group: GroupToken) => {
+const unifyPunctuationHandler: Handler = (token: Token, _, group: GroupToken) => {
   // full-width: comma, full stop, colon, quotes
   // half-width: brackets
   // no change for half-width punctuation between half-width content without space
@@ -162,4 +162,4 @@ const handler: Handler = (token: Token, _, group: GroupToken) => {
   }
 }
 
-export default handler
+export default unifyPunctuationHandler

--- a/test/example-todo.md
+++ b/test/example-todo.md
@@ -1,0 +1,1 @@
+hello world

--- a/test/todo.test.ts
+++ b/test/todo.test.ts
@@ -1,0 +1,15 @@
+import { describe, test } from 'vitest'
+
+import fs from 'fs'
+import path from 'path'
+import run from '../src/run'
+
+describe('lint', () => {
+  test('ignore HTML comment', () => {
+    const input = fs.readFileSync(
+      path.resolve(__dirname, './example-todo.md'),
+      { encoding: 'utf8' }
+    )
+    run(input)
+  })
+})


### PR DESCRIPTION
开发模式下更好的规则调试体验，在日志里会看到类似这样的输入：

```
[Original value]
mark-raw：a `b` c `d`e`f` g`h`i
[After process by markRawHandler]
mark-raw：a `b` c `d` e `f` g `h` i
[Eventual value]
mark-raw：a `b` c `d` e `f` g `h` i

[Original value]
mark-type：a__[b](x)__c__[ d ](y)__e
[After process by markHyperHandler]
mark-type：a__[b](x)__c __[d](y)__ e
[Eventual value]
mark-type：a__[b](x)__c __[d](y)__ e

[Original value]
unify-punctuation：中文,中文 （中文） 中文'中文'中文"中文"中文 （中文）（中文）中文 （中文）。
[After process by unifyPunctuationHandler]
unify-punctuation：中文，中文 (中文) 中文‘中文’中文“中文”中文 (中文)(中文)中文 (中文)。
[After process by spaceBracketsHandler]
unify-punctuation：中文，中文 (中文) 中文‘中文’中文“中文”中文 (中文)(中文) 中文 (中文)。
[Eventual value]
unify-punctuation：中文，中文 (中文) 中文‘中文’中文“中文”中文 (中文)(中文) 中文 (中文)。
```