### PR TITLE
修复多余的 md 标记开头的空格

### DIFF
--- a/src/rules/mark-hyper.ts
+++ b/src/rules/mark-hyper.ts
@@ -47,10 +47,13 @@ const checkSpace = (group: GroupToken, markSeq: Token[]): boolean => {
 
 const markHyperHandler: Handler = (token: Token, _, group: GroupToken) => {
   if (token.type === SingleTokenType.MARK_HYPER) {
+    // Usually, it's `[`, `](...)`, etc.
     const markSeq = findMarkSeq(group, token)
     const tokenBeforeMarkSeq = findTokenBefore(group, markSeq[0])
     const hasSpace = checkSpace(group, markSeq)
 
+    // Only handle the case when the current token is the first in the seq to
+    // dedupe the logic.
     if (token === markSeq[0]) {
       const spaceAfterHost = findSpaceAfterHost(
         group,

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -291,4 +291,9 @@ describe('lint', () => {
       '详见[自定义指令指南](custom-directive.html)。'
     )
   })
+  test('space for md marker in the front', () => {
+    expect(lint('- [`<KeepAlive>` API 参考](/api/built-in-components.html#keepalive)')).toBe(
+      '- [`<KeepAlive>` API 参考](/api/built-in-components.html#keepalive)'
+    )
+  })
 })


### PR DESCRIPTION
例如之前：

```md
- [`<KeepAlive>` API 参考](/api/built-in-components.html#keepalive)
```

会被错误处理为

```md
- [ `<KeepAlive>` API 参考](/api/built-in-components.html#keepalive)
```

即多加一个空格。该 PR 用以修复这个 bug