### PR TITLE
禁止在未知 HTML 标记两侧修改空格

### DIFF
--- a/src/rules/mark-html.ts
+++ b/src/rules/mark-html.ts
@@ -1,0 +1,29 @@
+/**
+ * Remove all SPACE_AFTER validations besides unexpected HTML tags.
+ */
+
+import { ValidationTarget } from '../report'
+import {
+  Handler,
+  MutableGroupToken as GroupToken,
+  MutableToken as Token
+} from '../parser'
+import {
+  findTokenBefore,
+  isUnexpectedHtmlTag,
+  removeValidation
+} from './util'
+
+const markHyperHandler: Handler = (token: Token, _, group: GroupToken) => {
+  if (isUnexpectedHtmlTag(token)) {
+    const tokenBefore = findTokenBefore(group, token)
+    if (tokenBefore) {
+      removeValidation(tokenBefore, '', ValidationTarget.SPACE_AFTER)
+      tokenBefore.modifiedSpaceAfter = tokenBefore.spaceAfter
+    }
+    removeValidation(token, '', ValidationTarget.SPACE_AFTER)
+    token.modifiedSpaceAfter = token.spaceAfter
+  }
+}
+
+export default markHyperHandler

--- a/src/run.ts
+++ b/src/run.ts
@@ -16,6 +16,7 @@ import md from './hypers/md'
 
 import markRaw from './rules/mark-raw'
 import markHyper from './rules/mark-hyper'
+import markHtml from './rules/mark-html'
 import unifyPunctuation from './rules/unify-punctuation'
 import caseAbbr from './rules/case-abbr'
 import spaceFullWidthContent from './rules/space-full-width-content'
@@ -80,6 +81,7 @@ const hyperParseInfo = [
 const rulesInfo = [
   { name: 'mark-raw', value: markRaw },
   { name: 'mark-hyper', value: markHyper },
+  { name: 'mark-html', value: markHtml },
   { name: 'unify-punctuation', value: unifyPunctuation },
   { name: 'case-abbr', value: caseAbbr },
   { name: 'space-full-width-content', value: spaceFullWidthContent },


### PR DESCRIPTION
鉴于对于绝大多数 HTML 标记来说，我们并无法假定其是否需要用空格和周围的内容隔开，所以增加一条规则以恢复相关的修改。