### PR TITLE
Adjusted quote width

### DIFF
--- a/src/parser/util.ts
+++ b/src/parser/util.ts
@@ -415,10 +415,7 @@ export const isShorthand = (
   }
   const nextChar = str[index + 1]
   const nextType = checkCharType(nextChar)
-  if (nextType === CharType.LETTERS_HALF) {
-    return true
-  }
-  if (nextType === CharType.SPACE) {
+  if (nextType === CharType.LETTERS_HALF || nextType === CharType.SPACE) {
     if (!status.lastGroup) {
       return true
     }

--- a/src/report.ts
+++ b/src/report.ts
@@ -68,6 +68,8 @@ export type Validation = {
   target: ValidationTarget
 }
 
+const adjustedFullWidthPunctuations = `“”‘’`
+
 const generateMarker = (str: string, index: number): string => {
   const prefix = str.substring(0, index)
   let fullWidthCount = 0
@@ -76,12 +78,14 @@ const generateMarker = (str: string, index: number): string => {
     const charType = checkCharType(prefix[i])
     if (
       charType === CharType.LETTERS_FULL ||
-      charType === CharType.PUNCTUATION_FULL
+      charType === CharType.PUNCTUATION_FULL &&
+      adjustedFullWidthPunctuations.indexOf(prefix[i]) === -1
     ) {
       fullWidthCount++
     } else if (
       charType === CharType.LETTERS_HALF ||
-      charType === CharType.PUNCTUATION_HALF ||
+      charType === CharType.PUNCTUATION_HALF &&
+      adjustedFullWidthPunctuations.indexOf(prefix[i]) !== -1 ||
       charType === CharType.SPACE
     ) {
       halfWidthCount++

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -45,6 +45,7 @@ export const defaultConfig: Options = {
   noSinglePair: true,
   halfWidthPunctuation: `()`,
   fullWidthPunctuation: `，。：；？！“”‘’`,
+  adjustedFullWidthPunctuation: `“”‘’`,
   unifiedPunctuation: 'simplified',
   spaceBetweenHalfWidthLetters: true,
   noSpaceBetweenFullWidthLetters: true,

--- a/src/rules/punctuation-width.ts
+++ b/src/rules/punctuation-width.ts
@@ -6,6 +6,7 @@
  * Options:
  * - halfWidthPunctuation: string = `()`
  * - fullWidthPunctuation: string = `，。：；？！“”‘’`
+ * - adjustedFullWidthPunctuation: string = `“”‘’`
  *
  * Details:
  * - skip half-width punctuations between half-width content without space
@@ -55,6 +56,16 @@ const widthSidePairList: WidthSidePairList = [
 
 const defaultHalfWidthOption = `()`
 const defaultFullWidthOption = `，。：；？！“”‘’`
+const defaultAdjustedFullWidthOption = `“”‘’`
+
+const checkAdjusted = (
+  token: MutableToken,
+  adjusted: string
+): void => {
+  if (adjusted.indexOf(token.modifiedContent) >= 0) {
+    token.modifiedType = CharType.PUNCTUATION_HALF
+  }
+}
 
 const parseOptions = (
   options: Options
@@ -62,9 +73,11 @@ const parseOptions = (
   halfWidthMap: AlterMap
   fullWidthMap: AlterMap
   fullWidthPairMap: AlterPairMap
+  adjusted: string
 } => {
   const halfWidthOption = options?.halfWidthPunctuation || ''
   const fullWidthOption = options?.fullWidthPunctuation || ''
+  const adjustedFullWidthOption = options?.adjustedFullWidthPunctuation || ''
 
   const halfWidthMap: AlterMap = {}
   const fullWidthMap: AlterMap = {}
@@ -93,12 +106,14 @@ const parseOptions = (
   return {
     halfWidthMap,
     fullWidthMap,
-    fullWidthPairMap
+    fullWidthPairMap,
+    adjusted: adjustedFullWidthOption
   }
 }
 
 const generateHandler = (options: Options): Handler => {
-  const { halfWidthMap, fullWidthMap, fullWidthPairMap } = parseOptions(options)
+  const { halfWidthMap, fullWidthMap, fullWidthPairMap, adjusted } =
+    parseOptions(options)
 
   const handleHyperSpaceOption: Handler = (
     token: MutableToken,
@@ -138,6 +153,7 @@ const generateHandler = (options: Options): Handler => {
           CharType.PUNCTUATION_FULL,
           PUNCTUATION_FULL_WIDTH
         )
+        checkAdjusted(token, adjusted)
       } else if (halfWidthMap[content]) {
         checkContent(
           token,
@@ -184,7 +200,8 @@ const generateHandler = (options: Options): Handler => {
 
 export const defaultConfig: Options = {
   halfWidthPunctuation: defaultHalfWidthOption,
-  fullWidthPunctuation: defaultFullWidthOption
+  fullWidthPunctuation: defaultFullWidthOption,
+  adjustedFullWidthPunctuation: defaultAdjustedFullWidthOption
 }
 
 export default generateHandler

--- a/src/rules/space-bracket.ts
+++ b/src/rules/space-bracket.ts
@@ -49,6 +49,10 @@ import {
   BRACKET_SPACE_OUTSIDE
 } from './messages'
 
+const isFullWidth = (char: string, adjusted: string): boolean => {
+  return isFullWidthPair(char) && adjusted.indexOf(char) === -1
+}
+
 const shouldSkip = (
   before: MutableToken | undefined,
   beforeTokenSeq: MutableToken[],
@@ -91,6 +95,7 @@ const generateHandler = (options: Options): Handler => {
   const noInsideBracketOption = options.noSpaceInsideBracket
   const spaceOutsideHalfBracketOption = options.spaceOutsideHalfBracket
   const noSpaceOutsideFullBracketOption = options.noSpaceOutsideFullBracket
+  const adjustedFullWidthOption = options.adjustedFullWidthPunctuation || ''
 
   return (token: MutableToken, _: number, group: MutableGroupToken) => {
     // skip non-bracket tokens
@@ -144,7 +149,7 @@ const generateHandler = (options: Options): Handler => {
       typeof spaceOutsideHalfBracketOption !== 'undefined' ||
       noSpaceOutsideFullBracketOption
     ) {
-      const isFullWidth = isFullWidthPair(token.modifiedContent)
+      const fullWidth = isFullWidth(token.modifiedContent, adjustedFullWidthOption)
 
       // 2.1 right-bracket x left-bracket
       if (contentTokenAfter) {
@@ -154,7 +159,7 @@ const generateHandler = (options: Options): Handler => {
         ) {
           if (afterSpaceHost) {
             const hasFullWidth =
-              isFullWidth || isFullWidthPair(contentTokenAfter.modifiedContent)
+              fullWidth || isFullWidth(contentTokenAfter.modifiedContent, adjustedFullWidthOption)
 
             // 2.1.1 any-full-bracket
             // 2.1.2 right-half-bracket x left-half-bracket
@@ -191,9 +196,9 @@ const generateHandler = (options: Options): Handler => {
             // 2.2.1 content/right-quote/code x left-full-bracket
             // 2.2.2 content/right-quote/code x left-half-bracket
             if (
-              isFullWidth ||
+              fullWidth ||
               (contentTokenBefore.type === GroupTokenType.GROUP &&
-                isFullWidthPair(contentTokenBefore.modifiedEndContent))
+                isFullWidth(contentTokenBefore.modifiedEndContent, adjustedFullWidthOption))
             ) {
               if (noSpaceOutsideFullBracketOption) {
                 checkSpaceAfter(beforeSpaceHost, '', BRACKET_NOSPACE_OUTSIDE)
@@ -220,9 +225,9 @@ const generateHandler = (options: Options): Handler => {
             // 2.3.1 right-full-bracket x content/left-quote/code
             // 2.4.2 right-half-bracket x content/left-quote/code
             if (
-              isFullWidth ||
+              fullWidth ||
               (contentTokenAfter.type === GroupTokenType.GROUP &&
-                isFullWidthPair(contentTokenAfter.modifiedStartContent))
+                isFullWidth(contentTokenAfter.modifiedStartContent, adjustedFullWidthOption))
             ) {
               if (noSpaceOutsideFullBracketOption) {
                 checkSpaceAfter(afterSpaceHost, '', BRACKET_NOSPACE_OUTSIDE)

--- a/src/rules/space-quote.ts
+++ b/src/rules/space-quote.ts
@@ -47,10 +47,15 @@ import {
   QUOTE_SPACE_OUTSIDE
 } from './messages'
 
+const isFullWidth = (char: string, adjusted: string): boolean => {
+  return isFullWidthPair(char) && adjusted.indexOf(char) === -1
+}
+
 const generateHandler = (options: Options): Handler => {
   const noSpaceInsideQuoteOption = options.noSpaceInsideQuote
   const spaceOutsideHalfQuoteOption = options.spaceOutsideHalfQuote
   const noSpaceOutsideFullQuoteOption = options.noSpaceOutsideFullQuote
+  const adjustedFullWidthOption = options.adjustedFullWidthPunctuation || ''
 
   return (token: MutableToken, _: number, group: MutableGroupToken) => {
     // skip non-group tokens
@@ -98,12 +103,12 @@ const generateHandler = (options: Options): Handler => {
           contentTokenAfter
         )
         if (spaceHost) {
-          const isFullWidth =
-            isFullWidthPair(token.modifiedEndContent) ||
-            isFullWidthPair(contentTokenAfter.modifiedStartContent)
+          const fullWidth =
+            isFullWidth(token.modifiedEndContent, adjustedFullWidthOption) ||
+            isFullWidth(contentTokenAfter.modifiedStartContent, adjustedFullWidthOption)
           // 2.1.1 right-full-quote x left-full-quote
           // 2.1.2 right-half-quote x left-half-quote
-          if (isFullWidth) {
+          if (fullWidth) {
             if (noSpaceOutsideFullQuoteOption) {
               checkSpaceAfter(spaceHost, '', QUOTE_SPACE_OUTSIDE)
             }
@@ -132,11 +137,11 @@ const generateHandler = (options: Options): Handler => {
           token
         )
         if (spaceHost) {
-          const isFullWidth = isFullWidthPair(token.modifiedStartContent)
+          const fullWidth = isFullWidth(token.modifiedStartContent, adjustedFullWidthOption)
 
           // 2.2.1 content/code x left-full-quote
           // 2.2.2 content/code x left-half-quote
-          if (isFullWidth) {
+          if (fullWidth) {
             if (noSpaceOutsideFullQuoteOption) {
               checkSpaceAfter(spaceHost, '', QUOTE_NOSPACE_OUTSIDE)
             }
@@ -152,7 +157,7 @@ const generateHandler = (options: Options): Handler => {
         }
       }
 
-      // 2.3 right-quote x content/punctuation/code
+      // 2.3 right-quote x content/code
       if (
         contentTokenAfter &&
         (isLettersType(contentTokenAfter.type) ||
@@ -164,11 +169,11 @@ const generateHandler = (options: Options): Handler => {
           contentTokenAfter
         )
         if (spaceHost) {
-          const isFullWidth = isFullWidthPair(token.modifiedEndContent)
+          const fullWidth = isFullWidth(token.modifiedEndContent, adjustedFullWidthOption)
 
           // 2.3.1 right-full-quote x content/code
           // 2.3.2 right-half-quote x content/code
-          if (isFullWidth) {
+          if (fullWidth) {
             if (noSpaceOutsideFullQuoteOption) {
               checkSpaceAfter(spaceHost, '', QUOTE_NOSPACE_OUTSIDE)
             }

--- a/src/rules/util.ts
+++ b/src/rules/util.ts
@@ -20,6 +20,7 @@ export type Options = {
   // punctuation
   halfWidthPunctuation?: string
   fullWidthPunctuation?: string
+  adjustedFullWidthPunctuation?: string
   unifiedPunctuation?: 'traditional' | 'simplified'
 
   // case: abbrs

--- a/test/example-units-fixed.md
+++ b/test/example-units-fixed.md
@@ -2,7 +2,7 @@ mark-raw：a `b` c `d` e `f` g `h` i
 
 mark-type：a__[b](x)__c __[d](y)__ e
 
-unify-punctuation：中文，中文 (中文) 中文‘中文’中文“中文”中文 (中文)(中文) 中文 (中文)。
+unify-punctuation：中文，中文 (中文) 中文 ‘中文’ 中文 “中文” 中文 (中文)(中文) 中文 (中文)。
 
 case-abbr：Pure JavaScript (a.k.a. Vanilla)
 
@@ -16,9 +16,9 @@ case-backslash：a \# b 中文\# __中文__ \# 中文 __\#__ __中文__\#中文_
 
 space-brackets：(x)a(b)c (d) e (f) g (h) i (j) k (l) m __(a)__ b (__c__) d(e)
 
-space-quotes：a“hello world”b
+space-quotes：a “hello world” b
 
-case-traditional：a“b‘c’d”e
+case-traditional：a “b ‘c’ d” e
 
 case-datetime：2020/01/02 01:20:30 中文 2020 年1月1日0天0号0时0分00秒
 

--- a/test/uncategorized.test.ts
+++ b/test/uncategorized.test.ts
@@ -40,7 +40,7 @@ describe('lint by issues', () => {
 
   // https://github.com/Jinjiang/zhlint/issues/35
   test('#35 parse error', () => {
-    expect(getOutput('x‘x’x', options)).toBe('x‘x’x')
+    expect(getOutput('x‘x’x', options)).toBe('x ‘x’ x')
   })
 
   // https://github.com/Jinjiang/zhlint/issues/36
@@ -80,7 +80,7 @@ describe('lint from v3.cn.vuejs.org', () => {
   // https://github.com/Jinjiang/zhlint/issues/69
   test('#69 spaces around () and “”', () => {
     expect(getOutput('将静态的 HTML “激活” (hydrate) 为', options)).toBe(
-      '将静态的 HTML“激活”(hydrate) 为'
+      '将静态的 HTML “激活” (hydrate) 为'
     )
   })
   // https://github.com/Jinjiang/zhlint/issues/72


### PR DESCRIPTION
#90 

- 增加了一个选项：`adjustedFullWidthPunctuation`。里面的全角字符在计算空格的时候会被当作半角空格来处理。默认配置为 `“”‘’`
- 同时修复了错误报告在有全角引号时无法对其的问题