### PR TITLE
fix: validation for ignored cases

### DIFF
--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -40,9 +40,11 @@ const findIgnoredMarks = (
       const nextPossibleCurrentIndex = possibleStart + textStart.length
 
       if (!end) {
-        logger.log(
-          `ignore: ${str.substring(possibleStart, nextPossibleCurrentIndex)}`
-        )
+        if (globalThis.__DEV__) {
+          logger.log(
+            `ignore: ${str.substring(possibleStart, nextPossibleCurrentIndex)}`
+          )
+        }
         marks.push({
           start: possibleStart,
           end: nextPossibleCurrentIndex
@@ -56,7 +58,9 @@ const findIgnoredMarks = (
         if (endIndex === -1) {
           return
         } else {
-          logger.log(`ignore: ${str.substring(possibleStart, possibleEnd)}`)
+          if (globalThis.__DEV__) {
+            logger.log(`ignore: ${str.substring(possibleStart, possibleEnd)}`)
+          }
           marks.push({
             start: possibleStart,
             end: possibleEnd

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -14,4 +14,12 @@ describe('lint with different arguments', () => {
       })
     ).toBe('汉字和English之间需要有空格比如 half width content。')
   })
+  test('ignored cases from Vue docs', () => {
+    const output = run('# SSR？ {#ssr}', {
+      ...options,
+      ignoredCases: [{ textStart: '？ {#' }]
+    })
+    expect(output.result).toBe('# SSR？ {#ssr}')
+    expect(output.validations.length).toBe(0)
+  })
 })


### PR DESCRIPTION
Previously, the validations in the output sometimes don't match the result due to wrong index calculations. Now it's been fixed.
Also, the logs for ignored cases would only on enabled in dev mode.