### PR TITLE
fix(case-zh-units): an error will be reported when `punctuation-full` appears after number

### DIFF
--- a/src/rules/case-zh-units.ts
+++ b/src/rules/case-zh-units.ts
@@ -36,6 +36,8 @@ const generateHandler = (options: Options): Handler => {
     if (token.type === CharType.LETTERS_HALF && token.content.match(/^\d+$/)) {
       // make sure the content after is a Chinese unit
       const tokenAfter = findNonCodeVisibleTokenAfter(group, token)
+
+      if (Array.isArray(tokenAfter)) return
       if (tokenAfter && tokenAfter.content.match(unitMatcher)) {
         // make sure there is no space between originally
         const { spaceHost: spaceHostAfter, tokens: tokenSeqAfter } =

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -447,6 +447,10 @@ describe('lint by cases', () => {
     expect(getOutput('2019年06月26号 2019-06-26 12:00', options)).toBe(
       '2019年06月26号 2019-06-26 12:00'
     )
+    expect(getOutput('1《测试》2【测试】3「测试」4（测试）', options)).toBe(
+      '1《测试》2【测试】3 “测试” 4 (测试)'
+    )
+    expect(getOutput('1？2！', options)).toBe('1？2！')
   })
   test('[case-abbrs]', () => {
     expect(getOutput('运行时 + 编译器 vs. 只包含运行时', options)).toBe(


### PR DESCRIPTION
fix: https://github.com/Jinjiang/zhlint/issues/106

当数字后面出现全角标点符号时，解析报错。我的处理思路是，数字后面出现全角标点符号，不应该当做“中文单位”处理，而“数字+中文单位”的情况下，`tokenAfter` 应该不会是数组，所以，遇到数组时直接返回即可。不知道这样的逻辑能否满足，如果有缺陷，还请指出 