### PR TITLE
feat: support zhlint --fix <file-pattern>[, ...] and fix path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ pnpm add zhlint -g
 ```bash
 # glob files, lint them, and print validation report,
 # and exit with code `1` if there is any error found.
-zhlint <file-pattern>
+zhlint <file-pattern>[, ...]
 
 # glob files and fix their all possilbly found errors.
-zhlint <file-pattern> --fix
+zhlint --fix <file-pattern>[, ...]
 
 # lint the file and output fixed content into another file
 zhlint <input-file-path> --output=<output-file-path>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,10 +24,10 @@ pnpm add zhlint -g
 ```bash
 # Glob 文件，执行格式化命令，并打印错误报告，
 # 如果有任何错误被发现，则会以错误码 `1` 退出。
-zhlint <file-pattern>
+zhlint <file-pattern>[, ...]
 
 # Glob 文件，并修复所有可能发现的错误。
-zhlint <file-pattern> --fix
+zhlint --fix <file-pattern>[, ...]
 
 # 格式化文件并将修复后的内容输出到另一个文件。
 zhlint <input-file-path> --output=<output-file-path>


### PR DESCRIPTION
- Add support for multiple file patterns with --fix flag
- Fix RangeError when using absolute paths with gitignore filter
- Update CLI help message and documentation
- Improve file pattern processing with deduplication
- Fix bug in fix logic (origin vs value comparison)

fix #162 